### PR TITLE
Enhance Supplier Plan Template Handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,8 @@
             }
         };
 
+        const originalSupplierTemplates = JSON.parse(JSON.stringify(supplierTemplates));
+
 
         // --- IndexedDB Helper Functions ---
         const DB_NAME = 'AmberDataCacheDB';
@@ -1155,6 +1157,9 @@
                     const option = document.createElement('option');
                     option.value = planName;
                     option.textContent = planName;
+                    if (!originalSupplierTemplates[selectedState] || !originalSupplierTemplates[selectedState][planName]) {
+                        option.style.color = '#1a56db';
+                    }
                     planSelector.appendChild(option);
                 });
             }
@@ -1221,6 +1226,10 @@
 
             if (!state || !planName) {
                 return; // Don't save if no state or name
+            }
+
+            if (originalSupplierTemplates[state] && originalSupplierTemplates[state][planName]) {
+                return;
             }
 
             const plan = createPlanObjectFromForm();


### PR DESCRIPTION
This commit introduces three key improvements to the management of supplier plan templates:

1.  **Prevent Template Overwriting:** The application now creates a deep copy of the original supplier templates on startup. This prevents any modifications or overwriting of the default templates, ensuring they remain intact.

2.  **Disallow Name Reuse:** A check has been added to prevent users from creating custom plans with the same names as the built-in templates. This avoids conflicts and potential confusion between default and user-created plans.

3.  **Visually Distinguish Custom Plans:** User-created custom plans are now displayed in a distinct blue color within the "Supplier Plan Templates" dropdown menu. This makes it easy for users to differentiate between the standard templates and their own custom plans at a glance.