### PR TITLE
Fix: Ensure average usage chart is destroyed before re-rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1306,6 +1306,7 @@
             messageContainer.classList.add('hidden');
             
             if (dailyUsageChart) { dailyUsageChart.destroy(); dailyUsageChart = null; }
+            if (usageChart) { usageChart.destroy(); usageChart = null; }
 
             const apiKey = document.getElementById('apiKey').value;
             const startDateValue = document.getElementById('startDate').value;


### PR DESCRIPTION
The 'Average 24-Hour Usage & Price' graph would disappear if the 'Compare Costs' button was clicked a second time. This was because the `usageChart` object was not being destroyed before the data was re-fetched and the results were re-displayed.

This change adds a line to destroy the `usageChart` instance and set its variable to `null` at the beginning of the `fetchData` function. This mirrors the existing logic for the `dailyUsageChart` and ensures that the average usage chart is always recreated and visible after every data fetch.