### PR TITLE
Constrain date inputs to prevent selecting 'today'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1064,9 +1064,11 @@
             const savedStartDate = localStorage.getItem('startDate');
             const savedEndDate = localStorage.getItem('endDate');
             
-            const today = new Date();
-            const maxDate = formatForInput(today);
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            const maxDate = formatForInput(yesterday);
             startDateInput.setAttribute('max', maxDate);
+            endDateInput.setAttribute('max', maxDate);
 
             if (savedStartDate && savedEndDate) {
                 startDateInput.value = savedStartDate;
@@ -1808,11 +1810,12 @@
             const overallStartDate = new Date(startDateValue + 'T00:00:00');
             let overallEndDate = new Date(endDateValue + 'T00:00:00');
             
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            yesterday.setHours(0, 0, 0, 0);
 
-            if (overallEndDate > today) {
-                overallEndDate = today;
+            if (overallEndDate > yesterday) {
+                overallEndDate = yesterday;
             }
             
             overallEndDate.setHours(23, 59, 59, 999); 


### PR DESCRIPTION
Changes the `max` attribute on both start and end date inputs to "yesterday" (instead of "today") preventing the user from picking today or future dates. Updated the internal date clamping in the fetching logic to also use "yesterday" to match the UI constraints.

---
*PR created automatically by Jules for task [8744135830813269480](https://jules.google.com/task/8744135830813269480) started by @RickUsingGitHub*